### PR TITLE
Fixed weekday format

### DIFF
--- a/python/mkdata.py
+++ b/python/mkdata.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 import sys
-import datetime
+from datetime import date
 
 if len(sys.argv) < 3:
     print 'Usage: schema clickfiles'
@@ -32,5 +32,7 @@ for l in fi:
         fo.write('1')
     else:
         fo.write('0')
-    fo.write('\t%d\t%s\t' % (int(arr[tindex][6:8]) % 7, arr[tindex][8:10]))
+    ts = arr[tindex]
+    d = date(int(ts[0:4]), int(ts[4:6]), int(ts[6:8]))
+    fo.write('\t%d\t%s\t' % (int(d.strftime("%w")), arr[tindex][8:10]))
     fo.write( l )

--- a/python/mktest.py
+++ b/python/mktest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 import sys
-import datetime
+from datetime import date
 
 if len(sys.argv) < 2:
     print 'Usage: schema '
@@ -24,5 +24,7 @@ for l in fi:
         fo.write('0')
     else:
         fo.write('1')
-    fo.write('\t%d\t%s\t' % (int(arr[tindex][6:8]) % 7, arr[tindex][8:10]))
+    ts = arr[tindex]
+    d = date(int(ts[0:4]), int(ts[4:6]), int(ts[6:8]))
+    fo.write('\t%d\t%s\t' % (int(d.strftime("%w")), arr[tindex][8:10]))
     fo.write( l )


### PR DESCRIPTION
Weekday should mean day of week, rather than `(day of month)%7`. The updated code does not affect the run time and fixes the day of week assignment using the python datetime library.

Note that using `strftime("%w")` assigns 0 to Sunday, 1 to Monday etc.